### PR TITLE
Add basic Flask POS webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # POSf
-POS webapp for a pharmacy
+
+A minimal point-of-sale web application for a pharmacy built with Flask. It can load products from an Excel sheet, create a shopping cart and store transactions.
+
+## Setup
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run the application:
+
+```bash
+python run.py
+```
+
+Open `http://localhost:5000` in your browser.
+
+## Loading products
+
+Use the **Upload** page to load an Excel file. The file should contain two columns: `name` and `price`. The first row is treated as the header.
+
+## Running tests
+
+```
+pytest
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,25 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+def create_app(config=None):
+    app = Flask(__name__, template_folder='../templates')
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI='sqlite:///pos.db',
+        SECRET_KEY='dev-secret-key',
+    )
+    if config:
+        app.config.update(config)
+
+    db.init_app(app)
+
+    from . import routes
+    app.register_blueprint(routes.bp)
+
+    with app.app_context():
+        db.create_all()
+
+    return app

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,22 @@
+from . import db
+from datetime import datetime
+import json
+
+
+class Product(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    price = db.Column(db.Float, nullable=False)
+
+
+class Transaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    items = db.Column(db.Text, nullable=False)  # JSON list
+    total = db.Column(db.Float, nullable=False)
+
+    def set_items(self, items_list):
+        self.items = json.dumps(items_list)
+
+    def get_items(self):
+        return json.loads(self.items)

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,80 @@
+from flask import Blueprint, render_template, request, redirect, url_for
+from flask import session
+from . import db
+from .models import Product, Transaction
+from openpyxl import load_workbook
+
+bp = Blueprint('pos', __name__)
+
+
+def get_cart():
+    return session.setdefault('cart', {})
+
+
+@bp.route('/')
+def index():
+    products = Product.query.all()
+    return render_template('products.html', products=products)
+
+
+@bp.route('/upload', methods=['GET', 'POST'])
+def upload():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if file:
+            wb = load_workbook(file)
+            ws = wb.active
+            for row in ws.iter_rows(min_row=2, values_only=True):
+                name, price = row[:2]
+                if name and price is not None:
+                    product = Product(name=str(name), price=float(price))
+                    db.session.add(product)
+            db.session.commit()
+            return redirect(url_for('pos.index'))
+    return render_template('upload.html')
+
+
+@bp.route('/add/<int:product_id>')
+def add_to_cart(product_id):
+    cart = get_cart()
+    cart[str(product_id)] = cart.get(str(product_id), 0) + 1
+    session.modified = True
+    return redirect(url_for('pos.index'))
+
+
+@bp.route('/cart')
+def view_cart():
+    cart = get_cart()
+    items = []
+    total = 0
+    for pid, qty in cart.items():
+        product = Product.query.get(int(pid))
+        if product:
+            subtotal = product.price * qty
+            items.append({'product': product, 'qty': qty, 'subtotal': subtotal})
+            total += subtotal
+    return render_template('cart.html', items=items, total=total)
+
+
+@bp.route('/checkout', methods=['POST'])
+def checkout():
+    cart = get_cart()
+    items = []
+    total = 0
+    for pid, qty in cart.items():
+        product = Product.query.get(int(pid))
+        if product:
+            items.append({
+                'id': product.id,
+                'name': product.name,
+                'price': product.price,
+                'qty': qty
+            })
+            total += product.price * qty
+    if items:
+        tx = Transaction(total=total)
+        tx.set_items(items)
+        db.session.add(tx)
+        db.session.commit()
+    session['cart'] = {}
+    return redirect(url_for('pos.index'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-SQLAlchemy
+openpyxl

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>POS</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="p-3">
+    <nav class="mb-3">
+        <a href="{{ url_for('pos.index') }}">Products</a> |
+        <a href="{{ url_for('pos.view_cart') }}">Cart</a> |
+        <a href="{{ url_for('pos.upload') }}">Upload</a>
+    </nav>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Cart</h2>
+<form method="post" action="{{ url_for('pos.checkout') }}">
+<table class="table">
+    <tr><th>Name</th><th>Qty</th><th>Subtotal</th></tr>
+    {% for item in items %}
+    <tr>
+        <td>{{ item.product.name }}</td>
+        <td>{{ item.qty }}</td>
+        <td>{{ '%.2f'|format(item.subtotal) }}</td>
+    </tr>
+    {% endfor %}
+    <tr>
+        <th colspan="2" class="text-end">Total</th>
+        <th>{{ '%.2f'|format(total) }}</th>
+    </tr>
+</table>
+<button class="btn btn-primary" type="submit">Checkout</button>
+</form>
+{% endblock %}

--- a/templates/products.html
+++ b/templates/products.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Products</h2>
+<table class="table">
+    <tr><th>Name</th><th>Price</th><th></th></tr>
+    {% for p in products %}
+    <tr>
+        <td>{{ p.name }}</td>
+        <td>{{ '%.2f'|format(p.price) }}</td>
+        <td>
+            <a class="btn btn-sm btn-success"
+               href="{{ url_for('pos.add_to_cart', product_id=p.id) }}">Add</a>
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Upload Products Excel</h2>
+<form method="post" enctype="multipart/form-data">
+    <div class="mb-3">
+        <input type="file" name="file" class="form-control" required>
+    </div>
+    <button class="btn btn-primary" type="submit">Upload</button>
+</form>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,36 @@
+import io
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT)
+
+from app import create_app, db
+from app.models import Product
+
+
+def test_upload_and_list(tmp_path):
+    db_uri = 'sqlite:///' + str(tmp_path / 'test.db')
+    app = create_app({'SQLALCHEMY_DATABASE_URI': db_uri, 'TESTING': True})
+    with app.app_context():
+        db.create_all()
+    client = app.test_client()
+
+    from openpyxl import Workbook
+    wb = Workbook()
+    ws = wb.active
+    ws.append(['name', 'price'])
+    ws.append(['Aspirin', 4.5])
+    file_stream = io.BytesIO()
+    wb.save(file_stream)
+    file_stream.seek(0)
+
+    response = client.post(
+        '/upload',
+        data={'file': (file_stream, 'products.xlsx')},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b'Aspirin' in response.data
+    with app.app_context():
+        assert Product.query.count() == 1


### PR DESCRIPTION
## Summary
- implement Flask app with SQLAlchemy models
- add routes to upload Excel files, manage cart and save transactions
- create minimal HTML templates
- provide tests for uploading an Excel sheet
- document setup and usage in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680e3e4ebc832ea8c7514ff11fe3c0